### PR TITLE
Fixes for issue of duplicate query parameters when paging is required

### DIFF
--- a/src/mixins/ListFilterBase.js
+++ b/src/mixins/ListFilterBase.js
@@ -1,10 +1,10 @@
-let link = "?";
 let request = require('request-promise');
 const listParams = ['user_id', 'client_id', 'project_id', 'is_billed', 'is_running', 'updated_since', 'from', 'to', 'page', 'per_page'];
 
 const listFilterBase = {
 
     listBy(params, cb) {
+        let link = "?";
         for (let datax in params) {
             if (listParams.indexOf(datax) !== -1) {
                 link = link + datax + '=' + params[datax] + '&';


### PR DESCRIPTION
Hi,

This is very small, but seems significant.

I have to support paging for time entries. This is not out of the box but you have to check for `next_page` and pass it to the `options` of the next request (— this is one of possible ways of doing that).

This means I have to perform this calls:

```javascript
var client = Harvest(...)

client.timeEntries.listBy({ page: 1 }, (...) => { });
// resolving promise, getting response, etc.; then
client.timeEntries.listBy({ page: 2 }, (...) => { });
// etc.
```

With current implementation the url that is being composed looks like (see comments):

```javascript
client.timeEntries.listBy({ page: 1 }, (...) => { });
// https://api.harvestapp.com/v2/timeEntries/?page=1
client.timeEntries.listBy({ page: 2 }, (...) => { });
// https://api.harvestapp.com/v2/timeEntries/?page=1&page2
```

which is wrong, but the behavior isn't surprising due to variable `link` which is global.

Therefore I moved it into the `listBy` scope.

What do you think?