### PR TITLE
Remove options.body for GET requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "harvest-v2",
+  "name": "@yaaqoub/harvest-v2",
   "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -751,9 +751,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -793,9 +793,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
@@ -879,6 +879,16 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -1402,9 +1412,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {
@@ -1454,9 +1464,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"
   },

--- a/src/mixins/Base.js
+++ b/src/mixins/Base.js
@@ -5,7 +5,7 @@ const base = {
     list(cb) {
         this.options.url = this.baseUri;
         this.options.method = 'GET';
-        this.options.json = true;
+
         return request(this.options, cb);
     },
 
@@ -16,7 +16,6 @@ const base = {
             this.options.url = this.baseUri;
         }
         this.options.method = 'GET';
-        this.options.json = true;
 
         return request(this.options, cb);
     },

--- a/src/mixins/Base.js
+++ b/src/mixins/Base.js
@@ -5,7 +5,6 @@ const base = {
     list(cb) {
         this.options.url = this.baseUri;
         this.options.method = 'GET';
-        this.options.body = '';
         this.options.json = true;
         return request(this.options, cb);
     },
@@ -17,7 +16,6 @@ const base = {
             this.options.url = this.baseUri;
         }
         this.options.method = 'GET';
-        this.options.body = '';
         this.options.json = true;
 
         return request(this.options, cb);

--- a/src/mixins/Base2.js
+++ b/src/mixins/Base2.js
@@ -5,7 +5,6 @@ const base2 = {
     list(id, cb) {
         this.options.url = this.baseUri + id + '/' + this.name;
         this.options.method = 'GET';
-        this.options.json = true;
 
         return request(this.options, cb);
     },
@@ -13,7 +12,6 @@ const base2 = {
     retrieve(id, otherId, cb) {
         this.options.url = this.baseUri + id + '/' + this.name + '/' + otherId;
         this.options.method = 'GET';
-        this.options.json = true;
 
         return request(this.options, cb);
     },

--- a/src/mixins/Base2.js
+++ b/src/mixins/Base2.js
@@ -5,7 +5,6 @@ const base2 = {
     list(id, cb) {
         this.options.url = this.baseUri + id + '/' + this.name;
         this.options.method = 'GET';
-        this.options.body = '';
         this.options.json = true;
 
         return request(this.options, cb);
@@ -14,7 +13,6 @@ const base2 = {
     retrieve(id, otherId, cb) {
         this.options.url = this.baseUri + id + '/' + this.name + '/' + otherId;
         this.options.method = 'GET';
-        this.options.body = '';
         this.options.json = true;
 
         return request(this.options, cb);

--- a/src/mixins/ListFilterBase.js
+++ b/src/mixins/ListFilterBase.js
@@ -13,7 +13,6 @@ const listFilterBase = {
 
         this.options.url = this.baseUri + '/' + link.slice(0, -1);
         this.options.method = 'GET';
-        this.options.body = '';
         this.options.json = true;
 
         return request(this.options, cb);

--- a/src/mixins/ListFilterBase.js
+++ b/src/mixins/ListFilterBase.js
@@ -13,7 +13,6 @@ const listFilterBase = {
 
         this.options.url = this.baseUri + '/' + link.slice(0, -1);
         this.options.method = 'GET';
-        this.options.json = true;
 
         return request(this.options, cb);
     },


### PR DESCRIPTION
From Harvest:

>  After August 15 2021, Harvest's new infrastructure will return an error on GET requests with content in the BODY payload. Requests matching this pattern will receive an error 400.

> Please ... adjust all GET requests to send an empty BODY payload following the HTTP 1.1 spec. We strongly recommend doing this well before August 15, 2021 in order to avoid any issues.