### PR TITLE
fix assignments api url

### DIFF
--- a/src/api/projectTaskAssignments.js
+++ b/src/api/projectTaskAssignments.js
@@ -4,7 +4,7 @@ const filterBase = require('../mixins/ListFilterBase');
 
 function ProjectTaskAssignments(options) {
   this.name = 'task_assignments';
-  this.baseUri = 'https://api.harvestapp.com/v2/projects/';
+  this.baseUri = `https://api.harvestapp.com/v2/${this.name}/`;
   this.options = options;
 }
 

--- a/src/api/projectUserAssignments.js
+++ b/src/api/projectUserAssignments.js
@@ -4,7 +4,7 @@ const filterBase = require('../mixins/ListFilterBase');
 
 function ProjectUserAssignments(options) {
   this.name = 'user_assignments';
-  this.baseUri = 'https://api.harvestapp.com/v2/projects/';
+  this.baseUri = `https://api.harvestapp.com/v2/${this.name}/`;
   this.options = options;
 }
 


### PR DESCRIPTION
Noticed these were using the /projects endpoint, changed to this.name as I saw was used in other places.