### PR TITLE
Add external_reference_id to listBy

### DIFF
--- a/src/mixins/ListFilterBase.js
+++ b/src/mixins/ListFilterBase.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch');
 
-const listParams = ['user_id', 'client_id', 'project_id', 'is_billed', 'is_running', 'updated_since', 'from', 'to', 'page', 'per_page', 'is_active'];
+const listParams = ['user_id', 'client_id', 'project_id', 'is_billed', 'is_running', 'updated_since', 'from', 'to', 'page', 'per_page', 'is_active', 'external_reference_id'];
 
 const listFilterBase = {
 


### PR DESCRIPTION
Add the ability to list by external_reference_id ... Useful for finding time entries relating to Asana tasks.